### PR TITLE
2-bit quantization

### DIFF
--- a/llama.py
+++ b/llama.py
@@ -269,7 +269,7 @@ if __name__ == "__main__":
         "--wbits",
         type=int,
         default=16,
-        choices=[3, 4, 16],
+        choices=[2, 3, 4, 16],
         help="#bits to use for quantization; use 16 for evaluating base model.",
     )
     parser.add_argument("--eval", action="store_true", help="evaluate quantized model.")

--- a/quantization/nuq.py
+++ b/quantization/nuq.py
@@ -27,7 +27,7 @@ parser.add_argument(
     type=int,
     default=3,
     help="bitwidth",
-    choices=[3, 4],
+    choices=[2, 3, 4],
 )
 parser.add_argument(
     "--range", type=str, default=None, help="range of layers to quantize"

--- a/quantization/pack.py
+++ b/quantization/pack.py
@@ -108,7 +108,7 @@ if __name__ == "__main__":
         "--wbits",
         type=int,
         default=16,
-        choices=[3, 4, 16],
+        choices=[2, 3, 4, 16],
         help="#bits to use for quantization; use 16 for evaluating base model.",
     )
     parser.add_argument(

--- a/squeezellm/quant_cuda.cpp
+++ b/squeezellm/quant_cuda.cpp
@@ -2,11 +2,20 @@
 #include <torch/python.h>
 #include <c10/cuda/CUDAGuard.h>
 
+
+void vecquant2matmul_nuq_perchannel_cuda(
+  torch::Tensor vec, torch::Tensor mat, torch::Tensor mul,
+  torch::Tensor lookup_table
+);
 void vecquant3matmul_nuq_perchannel_cuda(
   torch::Tensor vec, torch::Tensor mat, torch::Tensor mul,
   torch::Tensor lookup_table
 );
 void vecquant4matmul_nuq_perchannel_cuda(
+  torch::Tensor vec, torch::Tensor mat, torch::Tensor mul,
+  torch::Tensor lookup_table
+);
+void vecquant2matmul_nuq_perchannel_batched_cuda(
   torch::Tensor vec, torch::Tensor mat, torch::Tensor mul,
   torch::Tensor lookup_table
 );
@@ -19,6 +28,16 @@ void vecquant4matmul_nuq_perchannel_batched_cuda(
   torch::Tensor lookup_table
 );
 
+void vecquant2matmul_spmv_nuq_perchannel_cuda(
+  torch::Tensor rows,
+  torch::Tensor cols,
+  torch::Tensor mat,
+  torch::Tensor vec,
+  torch::Tensor mul,
+  int num_rows,
+  torch::Tensor mat2,
+  torch::Tensor lookup_table
+);
 void vecquant3matmul_spmv_nuq_perchannel_cuda(
   torch::Tensor rows,
   torch::Tensor cols,
@@ -37,6 +56,16 @@ void vecquant4matmul_spmv_nuq_perchannel_cuda(
   torch::Tensor mul,
   int num_rows,
   torch::Tensor mat4,
+  torch::Tensor lookup_table
+);
+void vecquant2matmul_spmv_nuq_perchannel_batched_cuda(
+  torch::Tensor rows,
+  torch::Tensor cols,
+  torch::Tensor mat,
+  torch::Tensor vec,
+  torch::Tensor mul,
+  int num_rows,
+  torch::Tensor mat2,
   torch::Tensor lookup_table
 );
 void vecquant3matmul_spmv_nuq_perchannel_batched_cuda(
@@ -109,6 +138,14 @@ void vecquant4matmul_spmv_hybrid_nuq_perchannel_batched_cuda(
   torch::Tensor lookup_table
 );
 
+
+void vecquant2matmul_nuq_perchannel(
+  torch::Tensor vec, torch::Tensor mat, torch::Tensor mul,
+  torch::Tensor lookup_table
+) {
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(vec));
+  vecquant2matmul_nuq_perchannel_cuda(vec, mat, mul, lookup_table);
+}
 void vecquant3matmul_nuq_perchannel(
   torch::Tensor vec, torch::Tensor mat, torch::Tensor mul,
   torch::Tensor lookup_table
@@ -122,6 +159,13 @@ void vecquant4matmul_nuq_perchannel(
 ) {
   const at::cuda::OptionalCUDAGuard device_guard(device_of(vec));
   vecquant4matmul_nuq_perchannel_cuda(vec, mat, mul, lookup_table);
+}
+void vecquant2matmul_nuq_perchannel_batched(
+  torch::Tensor vec, torch::Tensor mat, torch::Tensor mul,
+  torch::Tensor lookup_table
+) {
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(vec));
+  vecquant2matmul_nuq_perchannel_batched_cuda(vec, mat, mul, lookup_table);
 }
 void vecquant3matmul_nuq_perchannel_batched(
   torch::Tensor vec, torch::Tensor mat, torch::Tensor mul,
@@ -138,6 +182,19 @@ void vecquant4matmul_nuq_perchannel_batched(
   vecquant4matmul_nuq_perchannel_batched_cuda(vec, mat, mul, lookup_table);
 }
 
+void vecquant2matmul_spmv_nuq_perchannel(
+  torch::Tensor rows,
+  torch::Tensor cols,
+  torch::Tensor mat,
+  torch::Tensor vec,
+  torch::Tensor mul,
+  int num_rows,
+  torch::Tensor mat2,
+  torch::Tensor lookup_table
+) {
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(vec));
+  vecquant2matmul_spmv_nuq_perchannel_cuda(rows, cols, mat, vec, mul, num_rows, mat2, lookup_table);
+}
 void vecquant3matmul_spmv_nuq_perchannel(
   torch::Tensor rows,
   torch::Tensor cols,
@@ -165,6 +222,19 @@ void vecquant4matmul_spmv_nuq_perchannel(
   vecquant4matmul_spmv_nuq_perchannel_cuda(rows, cols, mat, vec, mul, num_rows, mat4, lookup_table);
 }
 
+void vecquant2matmul_spmv_nuq_perchannel_batched(
+  torch::Tensor rows,
+  torch::Tensor cols,
+  torch::Tensor mat,
+  torch::Tensor vec,
+  torch::Tensor mul,
+  int num_rows,
+  torch::Tensor mat2,
+  torch::Tensor lookup_table
+) {
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(vec));
+  vecquant2matmul_spmv_nuq_perchannel_batched_cuda(rows, cols, mat, vec, mul, num_rows, mat2, lookup_table);
+}
 void vecquant3matmul_spmv_nuq_perchannel_batched(
   torch::Tensor rows,
   torch::Tensor cols,
@@ -255,12 +325,16 @@ void vecquant4matmul_spmv_hybrid_nuq_perchannel_batched(
 }
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("vecquant2matmul_nuq_perchannel", &vecquant2matmul_nuq_perchannel, "Non-Uniform Vector 2-bit Quantized Matrix Multiplication w/ Per-Channel LUT (CUDA)");
   m.def("vecquant3matmul_nuq_perchannel", &vecquant3matmul_nuq_perchannel, "Non-Uniform Vector 3-bit Quantized Matrix Multiplication w/ Per-Channel LUT (CUDA)");
   m.def("vecquant4matmul_nuq_perchannel", &vecquant4matmul_nuq_perchannel, "Non-Uniform Vector 4-bit Quantized Matrix Multiplication w/ Per-Channel LUT (CUDA)");
+  m.def("vecquant2matmul_nuq_perchannel_batched", &vecquant2matmul_nuq_perchannel_batched, "Non-Uniform Vector 2-bit Quantized Matrix Multiplication w/ Per-Channel LUT (CUDA)");
   m.def("vecquant3matmul_nuq_perchannel_batched", &vecquant3matmul_nuq_perchannel_batched, "Non-Uniform Vector 3-bit Quantized Matrix Multiplication w/ Per-Channel LUT (CUDA)");
   m.def("vecquant4matmul_nuq_perchannel_batched", &vecquant4matmul_nuq_perchannel_batched, "Non-Uniform Vector 4-bit Quantized Matrix Multiplication w/ Per-Channel LUT (CUDA)");
+  m.def("vecquant2matmul_spmv_nuq_perchannel", &vecquant2matmul_spmv_nuq_perchannel, "Non-Uniform Vector 2-bit Quantized Matrix Multiplication w/ Per-Channel LUT (CUDA - Hybrid)");
   m.def("vecquant3matmul_spmv_nuq_perchannel", &vecquant3matmul_spmv_nuq_perchannel, "Non-Uniform Vector 3-bit Quantized Matrix Multiplication w/ Per-Channel LUT (CUDA - Hybrid)");
   m.def("vecquant4matmul_spmv_nuq_perchannel", &vecquant4matmul_spmv_nuq_perchannel, "Non-Uniform Vector 4-bit Quantized Matrix Multiplication w/ Per-Channel LUT (CUDA - Hybrid)");
+  m.def("vecquant2matmul_spmv_nuq_perchannel_batched", &vecquant2matmul_spmv_nuq_perchannel_batched, "Non-Uniform Vector 2-bit Quantized Matrix Multiplication w/ Per-Channel LUT (CUDA - Hybrid)");
   m.def("vecquant3matmul_spmv_nuq_perchannel_batched", &vecquant3matmul_spmv_nuq_perchannel_batched, "Non-Uniform Vector 3-bit Quantized Matrix Multiplication w/ Per-Channel LUT (CUDA - Hybrid)");
   m.def("vecquant4matmul_spmv_nuq_perchannel_batched", &vecquant4matmul_spmv_nuq_perchannel_batched, "Non-Uniform Vector 4-bit Quantized Matrix Multiplication w/ Per-Channel LUT (CUDA - Hybrid)");
   m.def("vecquant3matmul_spmv_hybrid_nuq_perchannel", &vecquant3matmul_spmv_hybrid_nuq_perchannel, "Non-Uniform Vector 3-bit Quantized Matrix Multiplication w/ Per-Channel LUT (CUDA - Hybrid)");


### PR DESCRIPTION
Hi, thanks for the great work!

This PR is an attempt to add 2-bit support for SqueezeLLM. It introduces two new kernels: 

`VecQuant2MatMulKernelNUQPerChannel`
`VecQuant2MatMulKernelNUQPerChannelBatched`

We evaluated the 2-bit quantized Llama2-13b-hf (https://huggingface.co/meta-llama/Llama-2-13b-hf) on the wikitext task from lm-evaluation-harness (https://github.com/EleutherAI/lm-evaluation-harness), using a sequence length of 4096.

The pure 2-bit model achieved a perplexity of around 100.
The dense-and-sparse 2-bit + 0.45 model achieved 14.

Note that these numbers are lower than what have been reported in the appendix of the paper (Table F.8).
We guess this re-implementation does not exactly match the original one.